### PR TITLE
use utf8 source in russian and japanese examples

### DIFF
--- a/examples/language_demo_japanese.py
+++ b/examples/language_demo_japanese.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 '''
 Created on Dec 21, 2013
 
@@ -31,39 +33,39 @@ welcome_message = \
 '''
 
 
-@Gooey(language='japanese', program_name=u'\u30d7\u30ed\u30b0\u30e9\u30e0\u4f8b')
+@Gooey(language='japanese', program_name=u'プログラム例')
 def arbitrary_function():
-    desc = u"\u30b3\u30de\u30f3\u30c9\u30e9\u30a4\u30f3\u5f15\u6570\u3092\u5165\u529b\u3057\u3066\u304f\u3060\u3055\u3044"
-    file_help_msg = u"\u51e6\u7406\u3057\u305f\u3044\u30d5\u30a1\u30a4\u30eb\u306e\u540d\u524d"
+    desc = u"コマンドライン引数を入力してください"
+    file_help_msg = u"処理したいファイルの名前"
     my_cool_parser = GooeyParser(description=desc)
-    my_cool_parser.add_argument('foo', metavar=u"\u30d5\u30a1\u30a4\u30eb\u30d6\u30e9\u30a6\u30b6",
+    my_cool_parser.add_argument('foo', metavar=u"ファイルブラウザ",
                                 help=file_help_msg, widget="FileChooser")   # positional
 
     my_cool_parser.add_argument(
         '-d',
-        metavar=u'--\u30c7\u30e5\u30ec\u30fc\u30b7\u30e7\u30f3',
+        metavar=u'--デュレーション',
         default=2,
         type=int,
-        help=u'\u30d7\u30ed\u30b0\u30e9\u30e0\u51fa\u529b\u306e\u671f\u9593\uff08\u79d2\uff09'
+        help=u'プログラム出力の期間（秒）'
     )
 
     my_cool_parser.add_argument(
         '-s',
-        metavar=u'--\u30b9\u30b1\u30b8\u30e5\u30fc\u30eb',
-        help=u'\u65e5\u6642\u30d7\u30ed\u30b0\u30e9\u30e0\u3092\u958b\u59cb\u3059\u3079\u304d',
+        metavar=u'--スケジュール',
+        help=u'日時プログラムを開始すべき',
         widget='DateChooser'
     )
     my_cool_parser.add_argument(
         "-c",
-        metavar=u"--\u30b7\u30e7\u30fc\u30bf\u30a4\u30e0",
+        metavar=u"--ショータイム",
         action="store_true",
-        help=u"\u30ab\u30a6\u30f3\u30c8\u30c0\u30a6\u30f3\u30bf\u30a4\u30de\u30fc\u3092\u8868\u793a\u3057\u307e\u3059"
+        help=u"カウントダウンタイマーを表示します"
     )
     my_cool_parser.add_argument(
         "-p",
-        metavar=u"--\u30dd\u30fc\u30ba",
+        metavar=u"--ポーズ",
         action="store_true",
-        help=u"\u4e00\u6642\u505c\u6b62\u306e\u5b9f\u884c"
+        help=u"一時停止の実行"
     )
 
     args = my_cool_parser.parse_args()

--- a/examples/language_demo_russian.py
+++ b/examples/language_demo_russian.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 '''
 Created on Dec 21, 2013
 
@@ -14,36 +16,36 @@ from gooey import GooeyParser
 import message
 
 
-@Gooey(language='russian', program_name=u'\u041f\u0440\u0438\u043c\u0435\u0440 \u043f\u0440\u043e\u0433\u0440\u0430\u043c\u043c\u044b')
+@Gooey(language='russian', program_name=u'Пример программы')
 def arbitrary_function():
-    desc = u"\u041f\u0440\u0438\u043c\u0435\u0440 \u043f\u0440\u0438\u043b\u043e\u0436\u0435\u043d\u0438\u044f \u002c \u0447\u0442\u043e\u0431\u044b \u043f\u043e\u043a\u0430\u0437\u0430\u0442\u044c "
-    file_help_msg = u"\u0418\u043c\u044f \u0444\u0430\u0439\u043b\u0430\u002c \u043a\u043e\u0442\u043e\u0440\u044b\u0439 \u0432\u044b \u0445\u043e\u0442\u0438\u0442\u0435 \u043e\u0431\u0440\u0430\u0431\u043e\u0442\u0430\u0442\u044c"
+    desc = u"Пример приложения , чтобы показать "
+    file_help_msg = u"Имя файла, который вы хотите обработать"
 
     my_cool_parser = GooeyParser(description=desc)
 
     my_cool_parser.add_argument(
         'foo',
-        metavar=u"\u0432\u044b\u0431\u043e\u0440\u0430\u0444\u0430\u0439\u043b\u043e\u0432",
+        metavar=u"выборафайлов",
         help=file_help_msg,
         widget="FileChooser")
 
     my_cool_parser.add_argument(
         'bar',
-        metavar=u"\u041d\u0435\u0441\u043a\u043e\u043b\u044c\u043a\u043e \u0444\u0430\u0439\u043b\u043e\u0432 \u0421\u043e\u0445\u0440\u0430\u043d\u0438\u0442\u044c",
+        metavar=u"Несколько файлов Сохранить",
         help=file_help_msg,
         widget="MultiFileChooser")
 
     my_cool_parser.add_argument(
         '-d',
-        metavar=u'--\u043f\u0440\u043e\u0434\u043e\u043b\u0436\u0438\u0442\u0435\u043b\u044c\u043d\u043e\u0441\u0442\u044c',
+        metavar=u'--продолжительность',
         default=2,
         type=int,
-        help=u'\u041f\u0440\u043e\u0434\u043e\u043b\u0436\u0438\u0442\u0435\u043b\u044c\u043d\u043e\u0441\u0442\u044c \u0028 \u0432 \u0441\u0435\u043a\u0443\u043d\u0434\u0430\u0445 \u0029 \u043d\u0430 \u0432\u044b\u0445\u043e\u0434\u0435 \u043f\u0440\u043e\u0433\u0440\u0430\u043c\u043c\u044b')
+        help=u'Продолжительность ( в секундах ) на выходе программы')
 
     my_cool_parser.add_argument(
         '-s',
-        metavar=u'--\u043a\u0440\u043e\u043d \u002d \u0433\u0440\u0430\u0444\u0438\u043a',
-        help=u'\u0414\u0430\u0442\u0430',
+        metavar=u'--крон - график',
+        help=u'Дата',
         widget='DateChooser')
 
     args = my_cool_parser.parse_args()


### PR DESCRIPTION
This should make Japanese and Russian examples more readable.

Conversion procedure:

```console
python3 -c "open('language_demo_japanese_utf8.py','wb').write(open('language_demo_japanese.py','rb').read().decode('raw_unicode_escape').encode('utf8'))"
python3 -c "open('language_demo_russian_utf8.py','wb').write(open('language_demo_russian.py','rb').read().decode('raw_unicode_escape').encode('utf8'))"
vim language_demo_japanese_utf8.py # add encoding comment at the top
vim language_demo_russian_utf8.py # add encoding comment at the top
mv language_demo_japanese_utf8.py language_demo_japanese.py 
mv language_demo_russian_utf8.py language_demo_russian.py 
```