### PR TITLE
remove inconsistent dashes

### DIFF
--- a/examples/message.py
+++ b/examples/message.py
@@ -26,7 +26,7 @@ See ya!
 
 
 def display_message():
-    message = program_message.format('\n-'.join(sys.argv[1:])).split('\n')
+    message = program_message.format('\n'.join(sys.argv[1:])).split('\n')
     delay = 1.8 / len(message)
 
     for line in message:


### PR DESCRIPTION
Prior to this commit, each arguments except the first
was prepended with a dash, which was confusing.