### PR TITLE
Update to fix dependency with wxpython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 RXPY>=0.1.0
-wxpython>=4.0.0b1
+wxpython == 4.0.7
 Pillow>=4.3.0
 psutil>=5.4.2
 Gooey>=1.0.1


### PR DESCRIPTION
We are using your software in a hackathon and many of us encountered an issue with compatibility with wxpython.  After some troubleshooting, we decided to change the requirements.txt and pin wxpython to 4.0.7.